### PR TITLE
Add reader class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,28 @@
+Language: Cpp
+BasedOnStyle:  LLVM
+AlwaysBreakTemplateDeclarations: Yes
+BreakBeforeBraces: Attach
+ColumnLimit: 160
+SpaceAfterTemplateKeyword: true
+Standard: c++17
+TabWidth: 4
+IndentWidth: 4
+UseTab: Always
+AllowShortEnumsOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: All
+AllowShortLambdasOnASingleLine: All
+AllowShortBlocksOnASingleLine: Always
+AllowShortIfStatementsOnASingleLine: Always
+AllowShortLoopsOnASingleLine: true
+IncludeCategories:
+  # Headers in <> without extension.
+  - Regex:           '<([A-Za-z0-9\/-_])+>'
+    Priority:        1
+  # Headers in <> with .h extension.
+  - Regex:           '<([A-Za-z0-9\/-_])+\.h>'
+    Priority:        10
+  # Headers in <> with .hpp extension.
+  - Regex:           '<([A-Za-z0-9\/-_])+\.hpp>'
+    Priority:        20
+PointerAlignment: Left

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.19)
 
 project(pini)
 add_executable(${PROJECT_NAME}  src/main.cpp
-                                src/util.cpp)
+                                src/util.cpp
+                                src/pini.cpp)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror=return-type)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,12 @@
+#include "pini.hpp"
 #include "util.hpp"
 #include <iostream>
 
 int main() {
-  std::vector<std::string> lines = util::get_lines("src/main.cpp");
-  for (auto str : lines) {
-    std::cout << str << std::endl;
+  pn::reader r;
+  r.read_file("test.ini");
+  std::unordered_map<std::string, std::string> key_value_pairs = r.get_pairs();
+  for (const auto &pair : key_value_pairs) {
+    std::cout << "key: " << pair.first << " value: " << pair.second << "\n";
   }
-  std::cout << "\n";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,8 @@
 
 int main() {
   pn::reader r;
-  r.read_file("test.ini");
+  std::string raw_input = {"a=5/b = 10/ 123= abcd"};
+  r.read_file(raw_input);
   std::unordered_map<std::string, std::string> key_value_pairs = r.get_pairs();
   for (const auto &pair : key_value_pairs) {
     std::cout << "key: " << pair.first << " value: " << pair.second << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,20 @@
+#include <ios>
+#include <iostream>
 #include "pini.hpp"
 #include "util.hpp"
-#include <iostream>
 
 int main() {
-  pn::reader r;
-  std::string raw_input = {"a=5\nb=10\n23=c"};
-  std::filesystem::path filename{"test/test.ini"};
-  r.read_file(raw_input);
-  std::unordered_map<std::string, std::string> key_value_pairs = r.get_pairs();
-  for (const auto &pair : key_value_pairs) {
-    std::cout << "key: " << pair.first << " value: " << pair.second << "\n";
-  }
+	pn::pini pin;
+
+	std::string_view raw_input{"a=5\nb=10\n23=c"};
+	std::filesystem::path filename{"test/test.ini"};
+
+	std::unordered_map<std::string, std::string> map = pin.get_pairs();
+
+	std::cout << std::boolalpha << pin.load_file(filename) << "\n";
+	std::cout << "attack: " << pin.get_uint32("attack ") << "\n";
+	std::cout << "def " << pin.get_uint64("def ") << "\n";
+	std::cout << "health " << pin.get_int64("health ") << "\n";
+	std::cout << "def " << pin.get_double("def ") << "\n";
+	std::cout << "sp " << pin.get_int32("skill points ") << "\n";
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,9 +4,9 @@
 
 int main() {
   pn::reader r;
-  std::string raw_input = {"a=5/b=10/23=c"};
+  std::string raw_input = {"a=5\nb=10\n23=c"};
   std::filesystem::path filename{"test/test.ini"};
-  r.read_file(filename);
+  r.read_file(raw_input);
   std::unordered_map<std::string, std::string> key_value_pairs = r.get_pairs();
   for (const auto &pair : key_value_pairs) {
     std::cout << "key: " << pair.first << " value: " << pair.second << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,8 +9,6 @@ int main() {
 	std::string_view raw_input{"a=5\nb=10\n23=c"};
 	std::filesystem::path filename{"test/test.ini"};
 
-	std::unordered_map<std::string, std::string> map = pin.get_pairs();
-
 	std::cout << std::boolalpha << pin.load_file(filename) << "\n";
 	std::cout << "attack: " << pin.get_uint32("attack ") << "\n";
 	std::cout << "def " << pin.get_uint64("def ") << "\n";

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,8 +4,9 @@
 
 int main() {
   pn::reader r;
-  std::string raw_input = {"a=5/b = 10/ 123= abcd"};
-  r.read_file(raw_input);
+  std::string raw_input = {"a=5/b=10/23=c"};
+  std::filesystem::path filename{"test/test.ini"};
+  r.read_file(filename);
   std::unordered_map<std::string, std::string> key_value_pairs = r.get_pairs();
   for (const auto &pair : key_value_pairs) {
     std::cout << "key: " << pair.first << " value: " << pair.second << "\n";

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -8,10 +8,8 @@
 
 namespace pn {
 namespace {
-
 pini::map_type read_file(std::filesystem::path const& filename) {
 	std::vector<std::string> lines = util::get_lines(filename);
-
 	return util::insert_pairs(lines);
 }
 

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -11,7 +11,7 @@ std::unordered_map<std::string, std::string> pn::reader::get_pairs() {
 }
 bool pn::reader::read_file(std::filesystem::path const &filename) {
 
-  std::vector<std::string> file_lines = util::get_lines(filename);
+  file_lines = util::get_lines(filename);
   if (file_lines.empty()) {
     return false;
   }
@@ -20,8 +20,6 @@ bool pn::reader::read_file(std::filesystem::path const &filename) {
   return true;
 }
 bool pn::reader::read_file(std::string const &raw_string) {
-  std::vector<std::string> file_lines;
-
   std::string str;
   std::istringstream str_stream(raw_string);
   while (getline(str_stream, str, '/')) {

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -1,32 +1,72 @@
 #include "pini.hpp"
-#include "util.hpp"
 #include <cstddef>
+#include <cstdint>
 #include <sstream>
+#include <string_view>
 #include <vector>
+#include "util.hpp"
 
 namespace pn {
+namespace {
 
-std::unordered_map<std::string, std::string> pn::reader::get_pairs() {
-  return reader::key_value_pairs;
+pini::map_type read_file(std::filesystem::path const& filename) {
+	std::vector<std::string> lines = util::get_lines(filename);
+
+	return util::insert_pairs(lines);
 }
-bool pn::reader::read_file(std::filesystem::path const &filename) {
 
-  file_lines = util::get_lines(filename);
-  if (file_lines.empty()) {
-    return false;
-  }
-  key_value_pairs = util::insert_pairs(file_lines);
-
-  return true;
+pini::map_type read_text(std::string_view text) {
+	std::string str;
+	std::stringstream str_stream;
+	str_stream << text;
+	std::vector<std::string> lines;
+	while (getline(str_stream, str, '\n')) { lines.push_back(str); }
+	return util::insert_pairs(lines);
 }
-bool pn::reader::read_file(std::string const &raw_string) {
-  std::string str;
-  std::istringstream str_stream(raw_string);
-  while (getline(str_stream, str, '\n')) {
-    file_lines.push_back(str);
-  }
-  key_value_pairs = util::insert_pairs(file_lines);
 
-  return true;
+} // namespace
+
+bool pini::load_file(std::filesystem::path const& filename) {
+	key_value_pairs = read_file(filename);
+	return !key_value_pairs.empty();
+}
+
+bool pini::load_text(std::string_view text) {
+	key_value_pairs = read_text(text);
+	return !key_value_pairs.empty();
+}
+
+double pini::get_double(std::string const& key, double def) const {
+	auto it = key_value_pairs.find(key);
+	if (it == key_value_pairs.end()) { return def; }
+	return std::atof(it->second.c_str());
+}
+
+std::uint64_t pini::get_uint64(std::string const& key, std::uint64_t def) const {
+	if (auto it = key_value_pairs.find(key); it != key_value_pairs.end()) {
+		try {
+			return stoull(it->second);
+		} catch (std::exception const& e) { std::cerr << e.what() << '\n'; }
+	}
+	return def;
+}
+
+std::int64_t pini::get_int64(std::string const& key, std::int64_t def) const {
+	if (auto it = key_value_pairs.find(key); it != key_value_pairs.end()) {
+		try {
+			return stoll(it->second);
+		} catch (std::exception const& e) { std::cerr << e.what() << '\n'; }
+	}
+	return def;
+}
+
+std::uint32_t pini::get_uint32(std::string const& key, std::uint32_t def) const { return static_cast<std::uint32_t>(pini::get_uint64(key, def)); }
+
+std::int32_t pini::get_int32(std::string const& key, std::uint32_t def) const { return static_cast<std::int32_t>(pini::get_int64(key, def)); }
+
+std::string_view pini::get_string(std::string const& key) const {
+	auto it = key_value_pairs.find(key);
+	if (it == key_value_pairs.end()) { return {}; }
+	return it->second;
 }
 } // namespace pn

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -1,5 +1,7 @@
 #include "pini.hpp"
 #include "util.hpp"
+#include <cstddef>
+#include <sstream>
 #include <vector>
 
 namespace pn {
@@ -13,20 +15,20 @@ bool pn::reader::read_file(std::filesystem::path const &filename) {
   if (file_lines.empty()) {
     return false;
   }
+  key_value_pairs = util::insert_pairs(file_lines);
 
-  std::string key;
-  std::string value;
-
-  for (const auto &str : file_lines) {
-    if (auto delimeter_pos = str.find('=');
-        delimeter_pos != std::string::npos) {
-      key = str.substr(0, delimeter_pos);
-      value = str.substr(delimeter_pos + 1);
-
-      key_value_pairs.insert({std::move(key), std::move(value)});
-    }
-  }
   return true;
 }
+bool pn::reader::read_file(std::string const &raw_string) {
+  std::vector<std::string> file_lines;
 
+  std::string str;
+  std::istringstream str_stream(raw_string);
+  while (getline(str_stream, str, '/')) {
+    file_lines.push_back(str);
+  }
+  key_value_pairs = util::insert_pairs(file_lines);
+
+  return true;
+}
 } // namespace pn

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -1,0 +1,33 @@
+#include "pini.hpp"
+#include "util.hpp"
+#include <vector>
+
+namespace pn {
+
+std::unordered_map<std::string, std::string> pn::reader::get_pairs() {
+  return reader::key_value_pairs;
+}
+bool pn::reader::read_file(std::filesystem::path const &filename) {
+
+  std::vector<std::string> file_lines = util::get_lines(filename);
+  if (file_lines.empty()) {
+    return false;
+  }
+
+  std::string key;
+  std::string value;
+  int delimeter_pos;
+
+  for (auto str : file_lines) {
+    delimeter_pos = str.find("=");
+    if (delimeter_pos != std::string::npos) {
+      key = str.substr(0, delimeter_pos);
+      value = str.substr(delimeter_pos + 1);
+
+      key_value_pairs.insert({key, value});
+    }
+  }
+  return true;
+}
+
+} // namespace pn

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -16,15 +16,14 @@ bool pn::reader::read_file(std::filesystem::path const &filename) {
 
   std::string key;
   std::string value;
-  int delimeter_pos;
 
-  for (auto str : file_lines) {
-    delimeter_pos = str.find("=");
-    if (delimeter_pos != std::string::npos) {
+  for (const auto &str : file_lines) {
+    if (auto delimeter_pos = str.find('=');
+        delimeter_pos != std::string::npos) {
       key = str.substr(0, delimeter_pos);
       value = str.substr(delimeter_pos + 1);
 
-      key_value_pairs.insert({key, value});
+      key_value_pairs.insert({std::move(key), std::move(value)});
     }
   }
   return true;

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -22,7 +22,7 @@ bool pn::reader::read_file(std::filesystem::path const &filename) {
 bool pn::reader::read_file(std::string const &raw_string) {
   std::string str;
   std::istringstream str_stream(raw_string);
-  while (getline(str_stream, str, '/')) {
+  while (getline(str_stream, str, '\n')) {
     file_lines.push_back(str);
   }
   key_value_pairs = util::insert_pairs(file_lines);

--- a/src/pini.hpp
+++ b/src/pini.hpp
@@ -13,7 +13,13 @@ class reader {
 
 public:
   std::unordered_map<std::string, std::string> get_pairs();
+  // TODO remove excess whitespace from strings
+
   bool read_file(std::filesystem::path const &filename);
+
+  // divide key-value pairs with `/`
+  // NOTE Must pass string variable. String literal will cause an overload error
+  bool read_file(std::string const &raw_string);
 };
 class pini {
   std::vector<std::string> file_lines;

--- a/src/pini.hpp
+++ b/src/pini.hpp
@@ -13,7 +13,7 @@ class pini {
   public:
 	using map_type = std::unordered_map<std::string, std::string>;
 
-	map_type get_pairs() { return key_value_pairs; }
+	const map_type& get_pairs() const { return key_value_pairs; }
 	bool load_file(std::filesystem::path const& filename);
 	bool load_text(std::string_view text);
 

--- a/src/pini.hpp
+++ b/src/pini.hpp
@@ -1,31 +1,37 @@
 #pragma once
 
-#include "util.hpp"
+#include <cstdint>
 #include <filesystem>
 #include <sstream>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
+#include "util.hpp"
 
 namespace pn {
-class reader {
-  std::vector<std::string> file_lines;
-  std::unordered_map<std::string, std::string> key_value_pairs;
-
-public:
-  std::unordered_map<std::string, std::string> get_pairs();
-  // TODO remove excess whitespace from strings
-
-  bool read_file(std::filesystem::path const &filename);
-
-  // divide key-value pairs with `/`
-  // NOTE Must pass string variable. String literal will cause an overload error
-  bool read_file(std::string const &raw_string);
-};
 class pini {
-  std::vector<std::string> file_lines;
+  public:
+	using map_type = std::unordered_map<std::string, std::string>;
 
-public:
-  int read_file(std::filesystem::path const &filename,
-                std::vector<std::string> &file_lines);
+	map_type get_pairs() { return key_value_pairs; }
+	bool load_file(std::filesystem::path const& filename);
+	bool load_text(std::string_view text);
+
+	// return double
+	double get_double(std::string const& key, double def = 0) const;
+	// return unsigned 64 bit integer - <unsigned long long>
+	std::uint64_t get_uint64(std::string const& key, std::uint64_t def = 0) const;
+	// return signed 64 bit integer  - <long long>
+	std::int64_t get_int64(std::string const& key, std::int64_t def = 0) const;
+
+	// return unsigned 32 bit integer
+	std::uint32_t get_uint32(std::string const& key, std::uint32_t def = 0) const;
+	// return signed 32 bit integer
+	std::int32_t get_int32(std::string const& key, std::uint32_t def = 0) const;
+	// return string value
+	std::string_view get_string(std::string const& key) const;
+
+  private:
+	map_type key_value_pairs;
 };
 } // namespace pn

--- a/src/pini.hpp
+++ b/src/pini.hpp
@@ -13,7 +13,7 @@ class pini {
   public:
 	using map_type = std::unordered_map<std::string, std::string>;
 
-	const map_type& get_pairs() const { return key_value_pairs; }
+	map_type const& get_pairs() const { return key_value_pairs; }
 	bool load_file(std::filesystem::path const& filename);
 	bool load_text(std::string_view text);
 

--- a/src/pini.hpp
+++ b/src/pini.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "util.hpp"
+#include <filesystem>
+#include <sstream>
+#include <unordered_map>
+#include <vector>
+
+namespace pn {
+class reader {
+  std::vector<std::string> file_lines;
+  std::unordered_map<std::string, std::string> key_value_pairs;
+
+public:
+  std::unordered_map<std::string, std::string> get_pairs();
+  bool read_file(std::filesystem::path const &filename);
+};
+class pini {
+  std::vector<std::string> file_lines;
+
+public:
+  int read_file(std::filesystem::path const &filename,
+                std::vector<std::string> &file_lines);
+};
+} // namespace pn

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,4 +1,5 @@
 #include "util.hpp"
+#include <cassert>
 
 namespace util {
 
@@ -15,14 +16,22 @@ std::vector<std::string> get_lines(std::filesystem::path const &filename) {
   return ret;
 }
 
-/* std::vector<std::string> separate_substrings(const std::string &str) {
-  std::vector<std::string> ret;
-  std::string word;
-  std::stringstream s_stream(str);
-  while (std::getline(s_stream, word, ' ')) {
-    ret.push_back(word);
+std::unordered_map<std::string, std::string>
+insert_pairs(std::vector<std::string> file_lines) {
+  std::unordered_map<std::string, std::string> key_value_pairs;
+  std::string key;
+  std::string value;
+
+  for (const auto &str : file_lines) {
+    if (auto delimeter_pos = str.find('=');
+        delimeter_pos != std::string::npos) {
+      key = str.substr(0, delimeter_pos);
+      value = str.substr(delimeter_pos + 1);
+
+      key_value_pairs.insert({std::move(key), std::move(value)});
+    }
   }
-  return ret;
-} */
+  return key_value_pairs;
+}
 
 } // namespace util

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,35 +3,26 @@
 
 namespace util {
 
-std::vector<std::string> get_lines(std::filesystem::path const &filename) {
-  std::vector<std::string> ret;
-  std::string temp_line;
-  if (auto file = std::ifstream(filename)) {
-    while (std::getline(file, temp_line)) {
-      ret.push_back(temp_line);
-    }
-  } else {
-    std::cout << "File failed to open\n";
-  }
-  return ret;
+std::vector<std::string> get_lines(std::filesystem::path const& filename) {
+	std::vector<std::string> ret;
+	std::string temp_line;
+	if (auto file = std::ifstream(filename)) {
+		while (std::getline(file, temp_line)) { ret.push_back(temp_line); }
+	} else {
+		std::cout << "File failed to open\n";
+	}
+	return ret;
 }
 
-std::unordered_map<std::string, std::string>
-insert_pairs(std::vector<std::string> file_lines) {
-  std::unordered_map<std::string, std::string> key_value_pairs;
-  std::string key;
-  std::string value;
+std::unordered_map<std::string, std::string> insert_pairs(std::vector<std::string> file_lines) {
+	std::unordered_map<std::string, std::string> key_value_pairs;
 
-  for (const auto &str : file_lines) {
-    if (auto delimeter_pos = str.find('=');
-        delimeter_pos != std::string::npos) {
-      key = str.substr(0, delimeter_pos);
-      value = str.substr(delimeter_pos + 1);
-
-      key_value_pairs.insert({std::move(key), std::move(value)});
-    }
-  }
-  return key_value_pairs;
+	for (const auto& str : file_lines) {
+		if (auto delimeter_pos = str.find('='); delimeter_pos != std::string::npos) {
+			key_value_pairs.insert({str.substr(0, delimeter_pos), str.substr(delimeter_pos + 1)});
+		}
+	}
+	return key_value_pairs;
 }
 
 } // namespace util

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -1,17 +1,19 @@
 #pragma once
-
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace util {
 // return vector of strings containing each line of the given file
 std::vector<std::string> get_lines(std::filesystem::path const &filename);
 
-// returns a vector of words contained in a string
-// std::vector<std::string> separate_substrings(const std::string &str);
+// extract key-value pairs from given vector of strings and insert them in an
+// unordered_map
+std::unordered_map<std::string, std::string>
+insert_pairs(std::vector<std::string> file_lines);
 } // namespace util

--- a/test.ini
+++ b/test.ini
@@ -1,3 +1,0 @@
-a=5
-dsaajd dsaj = 10
-843218 = dkjsajdsa

--- a/test.ini
+++ b/test.ini
@@ -1,3 +1,3 @@
-a = 5
+a=5
 dsaajd dsaj = 10
 843218 = dkjsajdsa

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,3 @@
+a = 5
+dsaajd dsaj = 10
+843218 = dkjsajdsa

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,3 +1,4 @@
-health = 10
+health = 9
 attack = 4.5
+def = -9.2314g
 skill points = 8

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,3 +1,3 @@
-a=5
-dsaajd dsaj = 10
-843218 = dkjsajdsa
+health = 10
+attack = 4.5
+skill points = 8

--- a/test/test.ini
+++ b/test/test.ini
@@ -1,0 +1,3 @@
+a=5
+dsaajd dsaj = 10
+843218 = dkjsajdsa


### PR DESCRIPTION
Added `reader` class that can can handle both file and string inputs.
```cpp
class reader {
  std::vector<std::string> file_lines;
  std::unordered_map<std::string, std::string> key_value_pairs;
public:
  std::unordered_map<std::string, std::string> get_pairs();
  bool read_file(std::filesystem::path const &filename);
  bool read_file(std::string const &raw_string);
}
```
This class is currently working and able to extract, save and pass the stored `unordered_map` to other variables and objects.
Due to `read_file()` being and overloaded function and `path` and `string` being very similar when passed as literals, they first need to be initialized as variables of their respective type and passed to the function.
When passing the data as a string to the function, the key-value pairs need to be divided with the char `/`, as shown in the code below: 

```cpp
  pn::reader r;
  std::string raw_input = {"a=5/b=10/23=c"};
  std::filesystem::path filename{"test/test.ini"};
  r.read_file(filename); // r.read_file(raw_input);
```
For future implementation there is one more problem I noticed, that needs to be solved : the `read_file()` function doesn't take care of excessive white space at the start or end of the string which could cause problems during search.
