### PR TITLE
Convert pini to a library

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+[*]
+insert_final_newline = true
+charset = utf-8
+indent_size = 4
+indent_style = tab
+# Optional: git will commit as lf, this will only affect local files
+end_of_line = lf
+
+[*.{py,md,yml,sh,cmake}]
+indent_style = space
+indent_size = 2
+
+[*.{py,md,yml,sh}.in]
+indent_style = space
+indent_size = 2
+
+[CMakeLists.txt]
+indent_style = space
+indent_size = 2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,16 @@
 cmake_minimum_required(VERSION 3.19)
 
 project(pini)
-add_executable(${PROJECT_NAME}  src/main.cpp
-                                src/util.cpp
-                                src/pini.cpp)
+add_library(${PROJECT_NAME}     src/util.cpp
+                                src/util.hpp
+                                src/pini.cpp
+                                include/pini/pini.hpp)
+add_library(pini::pini ALIAS pini)
+target_include_directories(${PROJECT_NAME} PRIVATE src PUBLIC include)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror=return-type)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+
+add_subdirectory(test)
 
 set(CCJSON "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json")
 if(EXISTS "${CCJSON}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,12 @@ target_include_directories(${PROJECT_NAME} PRIVATE src PUBLIC include)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror=return-type)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
-add_subdirectory(test)
+option(PINI_BUILD_TESTS "Build tests" ON)
+
+if(PINI_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(test)
+endif()
 
 set(CCJSON "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json")
 if(EXISTS "${CCJSON}")

--- a/include/pini/pini.hpp
+++ b/include/pini/pini.hpp
@@ -6,7 +6,6 @@
 #include <string_view>
 #include <unordered_map>
 #include <vector>
-#include "util.hpp"
 
 namespace pn {
 class pini {

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -1,10 +1,11 @@
-#include "pini.hpp"
 #include <cstddef>
 #include <cstdint>
 #include <sstream>
 #include <string_view>
 #include <vector>
-#include "util.hpp"
+#include <pini/pini.hpp>
+#include <util.hpp>
+
 
 namespace pn {
 namespace {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,5 +1,5 @@
-#include "util.hpp"
 #include <cassert>
+#include <util.hpp>
 
 namespace util {
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,3 +6,4 @@ target_link_libraries(${PROJECT_NAME} PRIVATE pini::pini)
 target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror=return-type)
 target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
 
+add_test(pini-test pini-test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.19)
+
+project(pini-test)
+add_executable(${PROJECT_NAME}  pini_test.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE pini::pini)
+target_compile_options(${PROJECT_NAME} PRIVATE -Wall -Wextra -Werror=return-type)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)
+

--- a/test/pini_test.cpp
+++ b/test/pini_test.cpp
@@ -5,13 +5,8 @@
 int main() {
 	pn::pini pin;
 
-	// std::string_view raw_input{"a=5\nb=10\n23=c"};
-	std::filesystem::path filename{"test/test.ini"};
-
-	std::cout << std::boolalpha << pin.load_file(filename) << "\n";
-	std::cout << "attack: " << pin.get_uint32("attack ") << "\n";
-	std::cout << "def " << pin.get_uint64("def ") << "\n";
-	std::cout << "health " << pin.get_int64("health ") << "\n";
-	std::cout << "def " << pin.get_double("def ") << "\n";
-	std::cout << "sp " << pin.get_int32("skill points ") << "\n";
+	std::string_view raw_input{"a=5\nb=10\n23=c"};
+	// std::filesystem::path filename{"/test/test.ini"};
+	if (!pin.load_text(raw_input)) { return 1; }
+	if (pin.get_int32("a") != 5) { return 1; }
 }

--- a/test/pini_test.cpp
+++ b/test/pini_test.cpp
@@ -1,12 +1,11 @@
 #include <ios>
 #include <iostream>
-#include "pini.hpp"
-#include "util.hpp"
+#include <pini/pini.hpp>
 
 int main() {
 	pn::pini pin;
 
-	std::string_view raw_input{"a=5\nb=10\n23=c"};
+	// std::string_view raw_input{"a=5\nb=10\n23=c"};
 	std::filesystem::path filename{"test/test.ini"};
 
 	std::cout << std::boolalpha << pin.load_file(filename) << "\n";


### PR DESCRIPTION
- Converted `pini` into a library and enabled `ctest`
- Divided source files into `src`, `include` and `test`
