### PR TITLE
fix: replace string_view with string to avoid missing letters

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 1,
+    "version": 2,
     "cmakeMinimumRequired": {
         "major": 3,
         "minor": 19,

--- a/include/pini/pini.hpp
+++ b/include/pini/pini.hpp
@@ -15,7 +15,7 @@ class pini {
 
 	map_type const& get_pairs() const { return key_value_pairs; }
 	bool load_file(std::filesystem::path const& filename);
-	bool load_text(std::string_view text);
+	bool load_text(std::string const& text);
 
 	// iteration
 

--- a/include/pini/util.hpp
+++ b/include/pini/util.hpp
@@ -17,9 +17,9 @@ std::vector<std::string> get_lines(std::filesystem::path const& filename);
 
 // extract key-value pairs from given vector of strings and insert them in an
 // unordered_map
-std::unordered_map<std::string, std::string> insert_pairs(std::vector<std::string> file_lines);
+std::unordered_map<std::string, std::string> insert_pairs(std::vector<std::string> const& file_lines);
 
-std::string_view trim_whitespace(std::string_view str);
+std::string trim_whitespace(std::string const& str);
 
 // data conversions:
 

--- a/src/pini.cpp
+++ b/src/pini.cpp
@@ -13,7 +13,7 @@ pini::map_type read_file(std::filesystem::path const& filename) {
 	return util::insert_pairs(lines);
 }
 
-pini::map_type read_text(std::string_view text) {
+pini::map_type read_text(std::string const& text) {
 	std::string str;
 	std::stringstream str_stream;
 	str_stream << text;
@@ -29,7 +29,7 @@ bool pini::load_file(std::filesystem::path const& filename) {
 	return !key_value_pairs.empty();
 }
 
-bool pini::load_text(std::string_view text) {
+bool pini::load_text(std::string const& text) {
 	key_value_pairs = read_text(text);
 	return !key_value_pairs.empty();
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1,7 +1,5 @@
-#include <cassert>
 #include <cctype>
-#include <cstddef>
-#include <string_view>
+
 #include <pini/pini.hpp>
 #include <pini/util.hpp>
 namespace pn {
@@ -20,13 +18,13 @@ std::vector<std::string> util::get_lines(std::filesystem::path const& filename) 
 	return ret;
 }
 
-std::unordered_map<std::string, std::string> util::insert_pairs(std::vector<std::string> file_lines) {
+std::unordered_map<std::string, std::string> util::insert_pairs(std::vector<std::string> const& file_lines) {
 	std::unordered_map<std::string, std::string> key_value_pairs;
 	std::size_t line_number = 0;
 	for (const auto& str : file_lines) {
 		++line_number;
 		if (auto delimeter_pos = str.find('='); delimeter_pos != std::string::npos) {
-			std::string_view const key = trim_whitespace(str.substr(0, delimeter_pos));
+			std::string const key = trim_whitespace(str.substr(0, delimeter_pos));
 			if (key.empty()) {
 				if (pn::pini::on_msg) {
 					std::stringstream str;
@@ -34,7 +32,7 @@ std::unordered_map<std::string, std::string> util::insert_pairs(std::vector<std:
 					(*pn::pini::on_msg)(str.str(), pn::pini::severity::warn);
 				}
 			} else {
-				std::string_view const value = trim_whitespace(str.substr(delimeter_pos + 1));
+				std::string const value = trim_whitespace(str.substr(delimeter_pos + 1));
 				if (key[0] != '#') { key_value_pairs.insert({std::string(key), std::string(value)}); }
 			}
 		}
@@ -42,7 +40,7 @@ std::unordered_map<std::string, std::string> util::insert_pairs(std::vector<std:
 	return key_value_pairs;
 }
 
-std::string_view util::trim_whitespace(std::string_view str) {
+std::string util::trim_whitespace(std::string const& str) {
 	if (str.empty()) { return {}; }
 	std::size_t start = 0;
 	std::size_t finish = str.size();

--- a/test/pini_test.cpp
+++ b/test/pini_test.cpp
@@ -5,22 +5,21 @@
 int main() {
 	pn::pini pin;
 
-	// std::string_view raw_input{"= 5\n#b=10\n c  = 23"};
-	std::filesystem::path filename{"/home/nikolaj/projects/cpp/pini/test/test.pini"};
+	std::string raw_input{"health = 9\nattack = 4.5\nb=32\n#comment\ndef = -9.2314\nskill points = 8\n"};
 	static int ret = 0;
-	pin.on_msg = [](std::string_view msg, pn::pini::severity level) {
+	pn::pini::on_msg = [](std::string_view msg, pn::pini::severity level) {
 		auto& out = level == pn::pini::severity::error ? std::cerr : std::cout;
 		out << "Custom: || " << msg << '\n';
 		if (level == pn::pini::severity::error) { ret = 1; }
 	};
-	if (!pin.load_file(filename)) { return 1; }
+	if (!pin.load_text(raw_input)) { return 1; }
 	if (pin.empty()) { return 1; }
 	if (pin.contains({})) { return 1; }
 	if (pin.contains("#comment")) { return 1; }
 	if (pin.get_int32("health") != 9) { return 1; }
 
 	for (auto& pair : pin) { std::cout << pair.first << " " << pair.second << '\n'; }
-	std::cout << pin.size() << " | " << pin.empty();
+	std::cout << pin.size() << " | " << pin.empty() << '\n';
 	pin.erase("def");
 	for (auto& pair : pin) { std::cout << pair.first << " " << pair.second << '\n'; }
 	return ret;

--- a/test/test.pini
+++ b/test/test.pini
@@ -1,6 +1,6 @@
 health = 9
 attack = 4.5
-= 32
+b=32
 #comment
 def = -9.2314
 skill points = 8


### PR DESCRIPTION
Fix bug where the first character of a key or value would get removed during assignment to the map.